### PR TITLE
Linkwitz riley crossover zero-phase magnitude plot

### DIFF
--- a/dsptoolbox/_general_helpers.py
+++ b/dsptoolbox/_general_helpers.py
@@ -482,11 +482,9 @@ def _fractional_octave_smoothing(vector: np.ndarray, num_fractions: int = 3,
         l1+1, vector, kind='cubic',
         copy=False, assume_sorted=True, axis=0)
     vec_log = vec_int(k_log)
-    # Smoothe by convolving with window
+    # Smoothe by convolving with window (output is centered)
     smoothed = scipy_convolve(vec_log, window[..., None],
-                              mode='full', method='auto')
-    # Take middle samples due to delay caused by the window
-    smoothed = smoothed[len(window)//2+1:len(window)//2+1+N]
+                              mode='same', method='auto')
     # Interpolate back to linear scale
     smoothed = interp1d(
         k_log, smoothed, kind='cubic',

--- a/dsptoolbox/filterbanks/_filterbank.py
+++ b/dsptoolbox/filterbanks/_filterbank.py
@@ -355,8 +355,10 @@ class LRFilterBank():
         if mode != 'parallel':
             warn('Plotting for LRFilterBank is only supported with parallel ' +
                  'mode. Setting to parallel')
+        delay_samples = int(0.5*length_samples) if zero_phase else 0
         d = dirac(
             length_samples=length_samples, number_of_channels=1,
+            delay_samples=delay_samples,
             sampling_rate_hz=self.sampling_rate_hz)
         bs = self.filter_signal(d, mode='parallel', activate_zi=test_zi,
                                 zero_phase=zero_phase)


### PR DESCRIPTION
- fixed a bug where the magnitude plots were shown incorrectly for the zero-phase filtering options